### PR TITLE
Set .spec.startingDeadlineSeconds for group sync cronjobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Initial implementation allowing to manage identity providers. 
+- Initial implementation allowing to manage identity providers.
 - Faciltiy to manage LDAP group sync.
 - Sudo process for cluster-admin ([#11])
 - LDAP group pruning ([#14])
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - ClusterRoleBinding for the LDAP sync job ([#10])
+- Set `.spec.startingDeadlineSeconds` for group sync cronjob ([#19])
 
 [Unreleased]: https://github.com/appuio/component-openshift4-authentication/compare/ba4fee5..HEAD
 
@@ -30,3 +31,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#14]: https://github.com/appuio/component-openshift4-authentication/pull/14
 [#15]: https://github.com/appuio/component-openshift4-authentication/pull/15
 [#16]: https://github.com/appuio/component-openshift4-authentication/pull/16
+[#19]: https://github.com/appuio/component-openshift4-authentication/pull/16

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ SHELL := bash
 FILES_JSONNET ?= $(shell find . -type f -name '*.*jsonnet' -or -name '*.libsonnet')
 FILES_YAML ?= $(shell find . -type f -name '*.yaml' -or -name '*.yml')
 
-JSONNETFMT_ARGS ?= --in-place
+JSONNETFMT_ARGS ?= --in-place --pad-arrays
 
 .PHONY: all
 all: lint

--- a/component/ldap.libsonnet
+++ b/component/ldap.libsonnet
@@ -48,7 +48,7 @@ local syncConfig(namespace, idp, sa) =
             template+: {
               spec+: {
                 local container(command) = kube.Container(command) {
-                  image: std.join(':', std.prune([params.images.sync.image, params.images.sync.tag])),
+                  image: std.join(':', std.prune([ params.images.sync.image, params.images.sync.tag ])),
                   command: [
                     'oc',
                     'adm',

--- a/component/ldap.libsonnet
+++ b/component/ldap.libsonnet
@@ -41,6 +41,7 @@ local syncConfig(namespace, idp, sa) =
     local volume = 'sync-config';
     com.namespaced(namespace, kube.CronJob(name) {
       spec+: {
+        startingDeadlineSeconds: 30,
         schedule: if std.objectHas(idp.ldap.sync, 'schedule') then idp.ldap.sync.schedule else params.ldapSync.schedule % (n % 60),
         jobTemplate+: {
           spec+: {

--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -79,7 +79,7 @@ local ldapSync =
   [
     ldapSyncServiceAccount,
     kube.ClusterRoleBinding('ldap-sync') {
-      subjects_: [ldapSyncServiceAccount],
+      subjects_: [ ldapSyncServiceAccount ],
       roleRef_: {
         kind: 'ClusterRole',
         metadata: {

--- a/component/rbac.libsonnet
+++ b/component/rbac.libsonnet
@@ -7,33 +7,33 @@ local inv = kap.inventory();
 local params = inv.parameters.openshift4_authentication;
 
 local sudoClusterRole = kube.ClusterRole('sudo-impersonator') {
-  rules: [{
-    apiGroups: [''],
-    resources: ['users'],
-    verbs: ['impersonate'],
-    resourceNames: [params.adminUserName],
+  rules: [ {
+    apiGroups: [ '' ],
+    resources: [ 'users' ],
+    verbs: [ 'impersonate' ],
+    resourceNames: [ params.adminUserName ],
   }, {
-    apiGroups: ['rbac.authorization.k8s.io'],
-    resources: ['clusterrolebindings', 'rolebindings'],
-    verbs: ['get', 'list', 'watch'],
-  }],
+    apiGroups: [ 'rbac.authorization.k8s.io' ],
+    resources: [ 'clusterrolebindings', 'rolebindings' ],
+    verbs: [ 'get', 'list', 'watch' ],
+  } ],
 };
 
 local sudoClusterRoleBinding = kube.ClusterRoleBinding(sudoClusterRole.metadata.name) {
-  subjects: [{
+  subjects: [ {
     apiGroup: 'rbac.authorization.k8s.io',
     kind: 'Group',
     name: params.sudoGroupName,
-  }],
+  } ],
   roleRef_: sudoClusterRole,
 };
 
 local sudoClusterRoleBindingView = kube.ClusterRoleBinding('sudo-view') {
-  subjects: [{
+  subjects: [ {
     apiGroup: 'rbac.authorization.k8s.io',
     kind: 'Group',
     name: params.sudoGroupName,
-  }],
+  } ],
   roleRef_: {
     kind: 'ClusterRole',
     metadata: {
@@ -43,11 +43,11 @@ local sudoClusterRoleBindingView = kube.ClusterRoleBinding('sudo-view') {
 };
 
 local clusterRoleBindingAdmin = kube.ClusterRoleBinding('impersonate-' + params.adminUserName) {
-  subjects: [{
+  subjects: [ {
     apiGroup: 'rbac.authorization.k8s.io',
     kind: 'User',
     name: params.adminUserName,
-  }],
+  } ],
   roleRef_: {
     kind: 'ClusterRole',
     metadata: {


### PR DESCRIPTION
The Kubernetes Cronjob scheduler will refuse to create new jobs for a cronjob which wasn't started for more than 100 times, from the [docs]:

> For every CronJob, the CronJob Controller checks how many schedules it missed in the duration from its last scheduled time until now. If there are more than 100 missed schedules, then it does not start the job and logs the error
>
> ```
> Cannot determine if job needs to be started. Too many missed start time (> 100). Set or decrease .spec.startingDeadlineSeconds or check clock skew.
> ```

However, if the `.spec.startingDeadlineSeconds` field is set, the scheduler instead checks how many missed jobs occurred in the last `startingDeadlineSeconds` seconds, instead of since the last schedule.

Therefore having `spec.startingDeadlineSeconds` set allows the cronjob to be scheduled again after it didn't work for a while (for whatever reason).

This commit sets `startingDeadlineSeconds` to 30 for the group sync cronjob.

[docs]: https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/

<!--
Thank you for your pull request. Please provide a description above and review
the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] keep pull requests small so they can be easily reviewed.
- [x] update ./CHANGELOG.md.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->
