### PR TITLE
Change parameter `identityProviders` to be a dictionary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v2.0.0]
+
+### Changed
+
+- Change parameter `identityProviders` to be a dictionary ([#20])
+
 ## [v1.0.0]
 ### Changed
 
@@ -25,8 +31,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - ClusterRoleBinding for the LDAP sync job ([#10])
 - Set `.spec.startingDeadlineSeconds` for group sync cronjob ([#19])
 
-[Unreleased]: https://github.com/appuio/component-openshift4-authentication/compare/v1.0.0..HEAD
+[Unreleased]: https://github.com/appuio/component-openshift4-authentication/compare/v2.0.0..HEAD
 [v1.0.0]: https://github.com/appuio/component-openshift4-authentication/releases/tag/v1.0.0
+[v2.0.0]: https://github.com/appuio/component-openshift4-authentication/releases/tag/v1.0.0
 
 [#9]: https://github.com/appuio/component-openshift4-authentication/pull/9
 [#10]: https://github.com/appuio/component-openshift4-authentication/pull/10
@@ -34,4 +41,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#14]: https://github.com/appuio/component-openshift4-authentication/pull/14
 [#15]: https://github.com/appuio/component-openshift4-authentication/pull/15
 [#16]: https://github.com/appuio/component-openshift4-authentication/pull/16
-[#19]: https://github.com/appuio/component-openshift4-authentication/pull/16
+[#19]: https://github.com/appuio/component-openshift4-authentication/pull/19
+[#20]: https://github.com/appuio/component-openshift4-authentication/pull/20

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -4,7 +4,7 @@ parameters:
     sudoGroupName: sudoers
     # Username to be used for impersonation, aka sudo
     adminUserName: cluster-admin
-    identityProviders: []
+    identityProviders: {}
 
     templates:
       # `error` has a speacial meaning for jsonnet. Using `err` isntead.

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -8,7 +8,11 @@ This reflects what is documented by `oc explain --api-version config.openshift.i
 The parameters `openshift4_authentication.templates.(err,login,providerSelection)` directly take the template string.
 The values will be written to a secret which then gets referenced in the OAuth CRD.
 
-As of know, the paramter `openshift4_authentication.identityProviders` requires at least one provider config of type LDAP.
+As of now, the parameter `openshift4_authentication.identityProviders` requires at least one provider config of type LDAP.
+The value of parameter `openshift4_authentication.identityProviders` must be a dictionary.
+However, the keys of the dictionary are only present to allow customizing the configuration of an identity provider later in the hierarchy.
+The keys themselves are not reflected anywhere in the generated configuration.
+Each value in the dictionary must be a valid identityProvider configuration for OpenShift 4.
 Additional provider configs can be of other types.
 The documentation requires to configure the LDAP bind password as a secret, and the CA certificate as a config map, the component accepts their literal value.
 Secrets and config maps will be created and referenced as needed only for LDAP provider configs.


### PR DESCRIPTION
This change enables users to adjust identity provider configurations in the hierarchy.

As documented, the keys of the dictionary are not reflected in the final configuration.

This is a breaking change, which we will release as v2.0.0 of the component.

<!--
Thank you for your pull request. Please provide a description above and review
the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] keep pull requests small so they can be easily reviewed.
- [x] update documentation.
- [x] update ./CHANGELOG.md.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->
