### PR TITLE
Configure LDAP group sync cronjob to run on master nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Configure LDAP group sync cronjob to run on master nodes ([#22])
+
 ## [v2.0.0]
 
 ### Changed
@@ -43,3 +47,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#16]: https://github.com/appuio/component-openshift4-authentication/pull/16
 [#19]: https://github.com/appuio/component-openshift4-authentication/pull/19
 [#20]: https://github.com/appuio/component-openshift4-authentication/pull/20
+[#22]: https://github.com/appuio/component-openshift4-authentication/pull/22

--- a/component/ldap.libsonnet
+++ b/component/ldap.libsonnet
@@ -71,6 +71,16 @@ local syncConfig(namespace, idp, sa) =
                 volumes_+: {
                   [volume]: { secret: { secretName: name } },
                 },
+                nodeSelector: {
+                  'node-role.kubernetes.io/master': '',
+                },
+                tolerations: [
+                  {
+                    key: 'node-role.kubernetes.io/master',
+                    operator: 'Exists',
+                    effect: 'NoSchedule',
+                  },
+                ],
               },
             },
           },

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -23,6 +23,11 @@ Secrets and config maps will be created and referenced as needed only for LDAP p
 The https://docs.openshift.com/container-platform/4.4/authentication/ldap-syncing.html[LDAP group sync] is configured to sync and prune groups from LDAP.
 Configured groups are synced from the LDAP provider and will be pruned once deleted again in LDAP.
 
+The sync cronjob is configured to be scheduled on the master nodes.
+The reason for this scheduling configuration stems from a combination of two factors: first, LDAP servers may be protected with IP allow-lists, and second, an OCP4 cluster may be deployed with public IPs for all nodes
+
+If both of those factors are combined, we need to add all the master node IPs to the allow-list, so that the control plane can talk to the LDAP server.
+In this scenario, if the LDAP sync cronjob is scheduled on the master nodes, we don't need to add additional infra or worker node IPs to the allow-list.
 
 == Cluster Admin Sudo
 


### PR DESCRIPTION
This limits the number of IPs that need to be allow-listed on LDAP servers which use IP allow-lists when deploying an OCP4 cluster on nodes with public IPs (e.g. on Exoscale).

<!--
Thank you for your pull request. Please provide a description above and review
the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] keep pull requests small so they can be easily reviewed.
- [x] update documentation.
- [x] update ./CHANGELOG.md.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->
