### PR TITLE
Manage group memberships via RBAC

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -7,7 +7,7 @@ parameters:
     identityProviders: {}
 
     templates:
-      # `error` has a speacial meaning for jsonnet. Using `err` isntead.
+      # `error` has a special meaning for jsonnet. Using `err` instead.
       err: ''
       login: ''
       providerSelection: ''

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -23,3 +23,5 @@ parameters:
       sync:
         image: image-registry.openshift-image-registry.svc:5000/openshift/cli
         tag: ~
+
+    groupMemberships: {}

--- a/class/openshift4-authentication.yml
+++ b/class/openshift4-authentication.yml
@@ -9,3 +9,7 @@ parameters:
           - openshift4-authentication/component/main.jsonnet
         input_type: jsonnet
         output_path: openshift4-authentication/
+      - input_paths:
+          - openshift4-authentication/component/groups.jsonnet
+        input_type: jsonnet
+        output_path: openshift4-authentication/

--- a/component/groups.jsonnet
+++ b/component/groups.jsonnet
@@ -1,0 +1,28 @@
+// main template for openshift4-authentication
+local com = import 'lib/commodore.libjsonnet';
+local kap = import 'lib/kapitan.libjsonnet';
+local kube = import 'lib/kube.libjsonnet';
+local inv = kap.inventory();
+// The hiera parameters for the component
+local params = inv.parameters.openshift4_authentication;
+
+
+local groups = std.prune([
+  local group = params.groupMemberships[groupName];
+
+  if com.getValueOrDefault(group, 'state', 'present') == 'present' && std.length(group.users) > 0 then kube.Group(groupName) {
+    subjects: std.prune([
+      if com.getValueOrDefault(group.users[userName], 'state', 'present') == 'present' then {
+        apiGroup: 'rbac.authorization.k8s.io',
+        kind: 'User',
+        name: userName,
+      }
+      for userName in std.objectFields(group.users)
+    ]),
+  }
+  for groupName in std.objectFields(params.groupMemberships)
+]);
+
+{
+  [if std.length(groups) > 0 then '31_groups']: groups,
+}

--- a/docs/modules/ROOT/pages/how-tos/group-memberships.adoc
+++ b/docs/modules/ROOT/pages/how-tos/group-memberships.adoc
@@ -1,0 +1,59 @@
+= Manage group memberships
+
+This page covers a guide on how to add or remove RBAC users to/from groups.
+
+== Add user
+
+Add a user to a group as an empty object.
+
+TIP: The name of the user is a name of the RBAC user resource, which might not be the one the user is using to log in.
+
+IMPORTANT: The name of the group is subject to some naming rules, see https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-label-names[DNS Label Names].
+
+[source,yaml]
+----
+parameters:
+  openshift4_authentication:
+    groupMemberships:
+      example-group:
+        users:
+          example-user: {}
+----
+
+[NOTE]
+====
+The `state` property can be specified explicitly, but is `present` already by default.
+[source,yaml]
+----
+          example-user:
+            state: present
+----
+====
+
+== Remove user
+
+If you have common groups "up" in the hierarchy, but want to remove a specific user from such a group, set the `state` property to `absent`.
+
+[source,yaml]
+----
+parameters:
+  openshift4_authentication:
+    groupMemberships:
+      example-group:
+        users:
+          removed-user:
+            state: absent
+----
+
+== Remove group
+
+If you have common groups "up" in the hierarchy, but want to avoid such a group being applied to the cluster, set the `state` property to `absent`.
+
+[source,yaml]
+----
+parameters:
+  openshift4_authentication:
+    groupMemberships:
+      removed-group:
+        state: absent
+----

--- a/docs/modules/ROOT/partials/nav.adoc
+++ b/docs/modules/ROOT/partials/nav.adoc
@@ -1,3 +1,4 @@
 * xref:index.adoc[Home]
 * How-to guides
-** xref:ldap-sync.adoc[LDAP Sync]
+** xref:how-tos/ldap-sync.adoc[LDAP Sync]
+** xref:how-tos/group-memberships.adoc[Manage group memberships]

--- a/tests/defaults.yml
+++ b/tests/defaults.yml
@@ -1,0 +1,14 @@
+parameters:
+  openshift4_authentication:
+    groupMemberships:
+      test-group:
+        users:
+          test-username: {}
+          absent-username:
+            state: absent
+      absent-group:
+        state: absent
+        users:
+          irrelevant-user: {}
+      empty-group:
+        users: {}


### PR DESCRIPTION
* Adds possibility to manage group memberships for users.

TL;DR: Interface looks like this:
```yaml
parameters:
  openshift4_authentication:
    groupMemberships:
      test-group:
        users:
          test-username: {}
          absent-username:
            state: absent
      absent-group:
        state: absent
        users:
          irrelevant-user: {}
      empty-group:
        users: {}
```

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
