### PR TITLE
Deprecated: 'bindPassword' as string parameter for LDAP IdP

### DIFF
--- a/docs/modules/ROOT/pages/references/deprecation-notice.adoc
+++ b/docs/modules/ROOT/pages/references/deprecation-notice.adoc
@@ -1,0 +1,23 @@
+= Deprecated features
+
+== v2.3.0
+
+The type of `openshift4_authentication.identityProviders.*.ldap.bindPassword` being a `string` reference to Vault is **deprecated** since the introduction of xref:how-tos/configure-secrets.adoc[Secret references].
+Users are encouraged to adopt the configuration like following, as the legacy syntax will be removed in a future release.
+
+[source,diff]
+----
+parameters:
+  openshift4_authentication:
+    identityProviders:
+      <name_of_the_provider>:
+        type: LDAP
+        ldap:
+-         bindPassword: "?{vaultkv:${customer:name}/${cluster:name}/ldap-auth/bindPassword}"
++         bindPassword:
++           name: ldap-bind <1>
++   secrets:
++     ldap-bind: <1>
++       bindPassword: '?{vaultkv:${cluster:tenant}/${cluster:name}/ldap-auth/bindPassword}'
+----
+<1> Those names have to match

--- a/docs/modules/ROOT/pages/references/deprecation-notice.adoc
+++ b/docs/modules/ROOT/pages/references/deprecation-notice.adoc
@@ -2,8 +2,10 @@
 
 == v2.3.0
 
-The type of `openshift4_authentication.identityProviders.*.ldap.bindPassword` being a `string` reference to Vault is **deprecated** since the introduction of xref:how-tos/configure-secrets.adoc[Secret references].
-Users are encouraged to adopt the configuration like following, as the legacy syntax will be removed in a future release.
+Directly providing a Vault secret reference as a string in `openshift4_authentication.identityProviders.*.ldap.bindPassword` is **deprecated**.
+Users should switch to the secret references mechanism, as documented in xref:how-tos/configure-secrets.adoc[configuring secrets for identity providers] how-to, as the legacy syntax will be removed in a future release.
+
+See below for an example diff showing how to restructure an LDAP identity provider configuration from the legacy syntax to secret references.
 
 [source,diff]
 ----
@@ -18,6 +20,8 @@ parameters:
 +           name: ldap-bind <1>
 +   secrets:
 +     ldap-bind: <1>
-+       bindPassword: '?{vaultkv:${cluster:tenant}/${cluster:name}/ldap-auth/bindPassword}'
++       bindPassword: '?{vaultkv:${cluster:tenant}/${cluster:name}/ldap-auth/bindPassword}' <2>
 ----
-<1> Those names have to match
+<1> Name of the secret containing the LDAP bind password.
+The name needs to be identical in both locations.
+<2> The bind password **must** be stored in key `bindPassword` in the secret.

--- a/docs/modules/ROOT/partials/nav.adoc
+++ b/docs/modules/ROOT/partials/nav.adoc
@@ -5,3 +5,5 @@
 ** xref:how-tos/configure-oidc-provider.adoc[Configure OIDC provider]
 ** xref:how-tos/group-memberships.adoc[Manage group memberships]
 
+* References
+** xref:references/deprecation-notice.adoc[Deprecated features]


### PR DESCRIPTION
The type of `openshift4_authentication.identityProviders.*.ldap.bindPassword` being a `string` reference to Vault is **deprecated** since the introduction of Secret references in #32.

Users are encouraged to adopt the configuration as outlined in this PR.

The parameter will be removed in the next major release.

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
