### PR TITLE
Prune deactivated identity providers

### DIFF
--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -26,7 +26,7 @@ local template = com.namespaced(params.namespace, kube.Secret('oauth-templates')
   },
 });
 
-local idps = params.identityProviders;
+local idps = std.prune(params.identityProviders);
 
 local configs = [
   local idp = idps[idpname];

--- a/component/secrets.jsonnet
+++ b/component/secrets.jsonnet
@@ -7,7 +7,7 @@ local inv = kap.inventory();
 // The hiera parameters for the component
 local params = inv.parameters.openshift4_authentication;
 
-local idps = params.identityProviders;
+local idps = std.prune(params.identityProviders);
 
 // To avoid breaking changes for LDAP, we support the identityProviders.<name>.ldap.bindPassword parameter
 local legacySecrets = [

--- a/tests/defaults.yml
+++ b/tests/defaults.yml
@@ -21,6 +21,7 @@ parameters:
       #  bindPassword: '?{vaultkv:${cluster:tenant}/${cluster:name}/ldap-auth/bindPassword}'
 
     identityProviders:
+      deletedProvider: null
       ldap-auth:
         name: Company LDAP
         type: LDAP


### PR DESCRIPTION
In case one would deactivate a provider via hierarchy by setting the key to `null`, compilation would fail.

```yaml
    identityProviders:
      deletedProvider: null
```

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
