### PR TITLE
Assign `cluster-read` instead of `view` to sudoers

### DIFF
--- a/component/rbac.libsonnet
+++ b/component/rbac.libsonnet
@@ -37,7 +37,7 @@ local sudoClusterRoleBindingView = kube.ClusterRoleBinding('sudo-view') {
   roleRef_: {
     kind: 'ClusterRole',
     metadata: {
-      name: 'view',
+      name: 'cluster-reader',
     },
   },
 };

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -33,12 +33,12 @@ In this scenario, if the LDAP sync cronjob is scheduled on the master nodes, we 
 
 RBAC rules are set up in order to allow a sudo like method to gain cluster-admin privileges.
 
-By default only `view` and `impersonate` permissions are granted to the group defined in `openshift4_authentication.sudoGroupName`.
+By default only `cluster-read` and `impersonate` permissions are granted to the group defined in `openshift4_authentication.sudoGroupName`.
 Using https://kubernetes.io/docs/reference/access-authn-authz/authentication/#user-impersonation[user impersonation], permissions can be escalated to full `cluster-admin`:
 
 [source,console]
 ----
-oc --as cluster-admin get nodes
+oc --as cluster-admin get secret
 ----
 
 The component also deploys a `RoleBinding` to ensure that users in the sudoers group can access the OpenShift cluster monitoring Alertmanager.

--- a/tests/golden/defaults/openshift4-authentication/openshift4-authentication/30_rbac.yaml
+++ b/tests/golden/defaults/openshift4-authentication/openshift4-authentication/30_rbac.yaml
@@ -50,7 +50,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: view
+  name: cluster-reader
 subjects:
   - apiGroup: rbac.authorization.k8s.io
     kind: Group


### PR DESCRIPTION
By assigning `cluster-read` to sudoers we enabled them to list and get nearly any resources. The main exceptions are CRDs that do not provide aggregated clusterroles to extend the default `cluster-read` clusterrole. This needs to be handled by the component introducing the CRD.

I will create follow up Issues for some of these components and prepare some best practice documentation when introducing CRDs in components.

## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
