### PR TITLE
Fix tenant name reclass references

### DIFF
--- a/docs/modules/ROOT/pages/references/deprecation-notice.adoc
+++ b/docs/modules/ROOT/pages/references/deprecation-notice.adoc
@@ -15,7 +15,7 @@ parameters:
       <name_of_the_provider>:
         type: LDAP
         ldap:
--         bindPassword: "?{vaultkv:${customer:name}/${cluster:name}/ldap-auth/bindPassword}"
+-         bindPassword: "?{vaultkv:${cluster:tenant}/${cluster:name}/ldap-auth/bindPassword}"
 +         bindPassword:
 +           name: ldap-bind <1>
 +   secrets:

--- a/tests/defaults.yml
+++ b/tests/defaults.yml
@@ -64,7 +64,7 @@ parameters:
               tolerateMemberOutOfScopeErrors: false
 
           # Deprecated: Using a string value is legacy. Newer version should use `bindPassword.name` and reference a secret name from `secrets` instead.
-          bindPassword: "?{vaultkv:${customer:name}/${cluster:name}/ldap-auth/bindPassword}"
+          bindPassword: "?{vaultkv:${cluster:tenant}/${cluster:name}/ldap-auth/bindPassword}"
           #bindPassword:
           #  name: ldap-bind
 


### PR DESCRIPTION
We've deprecated `customer.name` a while ago.




## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
