### PR TITLE
Make LDAP CA configuration optional

### DIFF
--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -42,7 +42,7 @@ local configs = [
     },
   })
   for idpname in std.objectFields(idps)
-  if idps[idpname].type == 'LDAP'
+  if idps[idpname].type == 'LDAP' && std.objectHas(idps[idpname].ldap, 'ca')
 ];
 
 local identityProviders = [
@@ -50,7 +50,7 @@ local identityProviders = [
 
   idp {
     ldap+: {
-      ca: { name: common.RefName(idp.name) },
+      [if std.objectHas(idp.ldap, 'ca') then 'ca']: { name: common.RefName(idp.name) },
       bindPassword:
         if std.isString(super.bindPassword) then
           // Legacy variant: value of `bindPassword` is a string, so we inject the secret name for the generated legacy secret

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -8,14 +8,19 @@ This reflects the documentation provided by `oc explain --api-version config.ope
 The parameters `openshift4_authentication.templates.(err,login,providerSelection)` directly take the template string.
 The values will be written to a secret which then gets referenced in the OAuth CRD.
 
-As of now, the parameter `openshift4_authentication.identityProviders` requires at least one provider config of type LDAP.
 The value of parameter `openshift4_authentication.identityProviders` must be a dictionary.
-However, the keys of the dictionary are only present to allow customizing the configuration of an identity provider later in the hierarchy.
+The keys of the dictionary are only present to allow customizing the configuration of an identity provider later in the hierarchy.
 The keys themselves aren't reflected anywhere in the generated configuration.
+
 Each value in the dictionary must be a valid identityProvider configuration for OpenShift 4.
-Additional provider configs can be of other types.
-The documentation requires to configure the LDAP bind password as a secret, and the CA certificate as a config map, the component accepts their literal value.
-Secrets and config maps will be created and referenced as needed only for LDAP provider configs.
+The component supports any type of provider config which is supported by Openshift 4.
+
+When configuring an LDAP identity provider which is secured with a certificate issued by a CA which is part of the system CA bundle, the LDAP server CA doesn't need to be specified explicitly.
+Otherwise, the CA can be provided as a literal string in field `ca` of the LDAP identity provider config.
+
+NOTE: Currently, the component only supports configuring a custom CA certificate for LDAP identity providers.
+
+Users should use the component's xref:how-tos/configure-secrets.adoc[secret configuration mechanism] to deploy secrets contiaining identity provider credentials.
 
 
 == LDAP Group Sync

--- a/tests/defaults.yml
+++ b/tests/defaults.yml
@@ -30,6 +30,8 @@ parameters:
       # this is the secret name in case if `bindPassword.name` is used:
       #ldap-bind:
       #  bindPassword: '?{vaultkv:${cluster:tenant}/${cluster:name}/ldap-auth/bindPassword}'
+      ldap2-bind:
+        bindPassword: ?{vaultkv:${cluster:tenant}/${cluster:name}/ldap2-auth/bindPassword}"
 
     identityProviders:
       deletedProvider: null
@@ -67,6 +69,35 @@ parameters:
           bindPassword: "?{vaultkv:${cluster:tenant}/${cluster:name}/ldap-auth/bindPassword}"
           #bindPassword:
           #  name: ldap-bind
+
+      ldap2:
+        name: Other LDAP
+        type: LDAP
+        ldap:
+          url: "ldaps://ldap.company.tld:636/ou=services,dc=company,dc=tld?uid"
+          bindDN: "uid=service,ou=idp,dc=company,dc=tld"
+          sync:
+            rfc2307:
+              groupsQuery:
+                baseDN: ou=Groups,dc=company,dc=tld
+                scope: sub
+                derefAliases: never
+                filter: "(&(objectclass=groupOfUniqueNames)(|(cn=cluster-admins)))"
+                pageSize: 0
+              groupUIDAttribute: dn
+              groupNameAttributes: [cn]
+              groupMembershipAttributes: [uniqueMember]
+              usersQuery:
+                baseDN: dc=company,dc=tld
+                scope: sub
+                derefAliases: never
+                pageSize: 0
+              userUIDAttribute: dn
+              userNameAttributes: [uid]
+              tolerateMemberNotFoundErrors: false
+              tolerateMemberOutOfScopeErrors: false
+          bindPassword:
+            name: ldap2-bind
 
       keycloak-auth:
         name: keycloak-auth

--- a/tests/golden/defaults/openshift4-authentication/openshift4-authentication/02_secrets.yaml
+++ b/tests/golden/defaults/openshift4-authentication/openshift4-authentication/02_secrets.yaml
@@ -9,6 +9,24 @@ metadata:
     app.kubernetes.io/component: openshift4-authentication
     app.kubernetes.io/managed-by: commodore
     app.kubernetes.io/name: openshift4-authentication
+    name: ldap2-bind
+  name: ldap2-bind
+  namespace: openshift-config
+stringData:
+  bindPassword: t-silent-test-1234/c-green-test-1234/ldap2-auth/bindPassword"
+type: Opaque
+---
+apiVersion: v1
+data: {}
+kind: Secret
+metadata:
+  annotations:
+    argocd.argoproj.io/compare-options: IgnoreExtraneous
+    argocd.argoproj.io/sync-options: Prune=false
+  labels:
+    app.kubernetes.io/component: openshift4-authentication
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/name: openshift4-authentication
     name: oidc-client
   name: oidc-client
   namespace: openshift-config

--- a/tests/golden/defaults/openshift4-authentication/openshift4-authentication/10_oauth.yaml
+++ b/tests/golden/defaults/openshift4-authentication/openshift4-authentication/10_oauth.yaml
@@ -16,6 +16,13 @@ spec:
         url: ldaps://ldap.company.tld:636/ou=services,dc=company,dc=tld?uid
       name: Company LDAP
       type: LDAP
+    - ldap:
+        bindDN: uid=service,ou=idp,dc=company,dc=tld
+        bindPassword:
+          name: ldap2-bind
+        url: ldaps://ldap.company.tld:636/ou=services,dc=company,dc=tld?uid
+      name: Other LDAP
+      type: LDAP
     - mappingMethod: add
       name: keycloak-auth
       openID:

--- a/tests/golden/defaults/openshift4-authentication/openshift4-authentication/20_ldap_sync.yaml
+++ b/tests/golden/defaults/openshift4-authentication/openshift4-authentication/20_ldap_sync.yaml
@@ -24,6 +24,24 @@ subjects:
     namespace: openshift-config
 ---
 apiVersion: v1
+data:
+  ca-bundle.crt: '-----BEGIN CERTIFICATE-----
+
+    -----END CERTIFICATE-----'
+kind: ConfigMap
+metadata:
+  annotations:
+    argocd.argoproj.io/compare-options: IgnoreExtraneous
+    argocd.argoproj.io/sync-options: Prune=false
+  labels:
+    app.kubernetes.io/component: openshift4-authentication
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/name: openshift4-authentication
+    name: ldap-sync-company-ldap-ca
+  name: ldap-sync-company-ldap-ca
+  namespace: openshift-config
+---
+apiVersion: v1
 data: {}
 kind: Secret
 metadata:
@@ -34,13 +52,10 @@ metadata:
   namespace: openshift-config
 stringData:
   blacklist.txt: ''
-  ca-bundle.crt: '-----BEGIN CERTIFICATE-----
-
-    -----END CERTIFICATE-----'
   config.yaml: "\"apiVersion\": \"v1\"\n\"bindDN\": \"uid=service,ou=idp,dc=company,dc=tld\"\
     \n\"bindPassword\": \"t-silent-test-1234/c-green-test-1234/ldap-auth/bindPassword\"\
-    \n\"ca\": \"/etc/sync-config/ca-bundle.crt\"\n\"kind\": \"LDAPSyncConfig\"\n\"\
-    rfc2307\":\n  \"groupMembershipAttributes\":\n  - \"uniqueMember\"\n  \"groupNameAttributes\"\
+    \n\"ca\": \"/etc/sync-config-ca/ca-bundle.crt\"\n\"kind\": \"LDAPSyncConfig\"\n\
+    \"rfc2307\":\n  \"groupMembershipAttributes\":\n  - \"uniqueMember\"\n  \"groupNameAttributes\"\
     :\n  - \"cn\"\n  \"groupUIDAttribute\": \"dn\"\n  \"groupsQuery\":\n    \"baseDN\"\
     : \"ou=Groups,dc=company,dc=tld\"\n    \"derefAliases\": \"never\"\n    \"filter\"\
     : \"(&(objectclass=groupOfUniqueNames)(|(cn=cluster-admins)))\"\n    \"pageSize\"\
@@ -90,6 +105,8 @@ spec:
               stdin: false
               tty: false
               volumeMounts:
+                - mountPath: /etc/sync-config-ca/
+                  name: ldap-ca
                 - mountPath: /etc/sync-config/
                   name: sync-config
             - args: []
@@ -110,6 +127,8 @@ spec:
               stdin: false
               tty: false
               volumeMounts:
+                - mountPath: /etc/sync-config-ca/
+                  name: ldap-ca
                 - mountPath: /etc/sync-config/
                   name: sync-config
           imagePullSecrets: []
@@ -124,9 +143,140 @@ spec:
               key: node-role.kubernetes.io/master
               operator: Exists
           volumes:
+            - configMap:
+                name: ldap-sync-company-ldap-ca
+              name: ldap-ca
             - name: sync-config
               secret:
                 secretName: ldap-sync-company-ldap
+  schedule: 49 * * * *
+  startingDeadlineSeconds: 30
+  successfulJobsHistoryLimit: 10
+---
+apiVersion: v1
+data: {}
+kind: ConfigMap
+metadata:
+  annotations:
+    argocd.argoproj.io/compare-options: IgnoreExtraneous
+    argocd.argoproj.io/sync-options: Prune=false
+  labels:
+    app.kubernetes.io/component: openshift4-authentication
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/name: openshift4-authentication
+    config.openshift.io/inject-trusted-cabundle: 'true'
+    name: ldap-sync-other-ldap-ca
+  name: ldap-sync-other-ldap-ca
+  namespace: openshift-config
+---
+apiVersion: v1
+data: {}
+kind: Secret
+metadata:
+  annotations: {}
+  labels:
+    name: ldap-sync-other-ldap
+  name: ldap-sync-other-ldap
+  namespace: openshift-config
+stringData:
+  blacklist.txt: ''
+  config.yaml: "\"apiVersion\": \"v1\"\n\"bindDN\": \"uid=service,ou=idp,dc=company,dc=tld\"\
+    \n\"bindPassword\": \"t-silent-test-1234/c-green-test-1234/ldap2-auth/bindPassword\\\
+    \"\"\n\"ca\": \"/etc/sync-config-ca/ca-bundle.crt\"\n\"kind\": \"LDAPSyncConfig\"\
+    \n\"rfc2307\":\n  \"groupMembershipAttributes\":\n  - \"uniqueMember\"\n  \"groupNameAttributes\"\
+    :\n  - \"cn\"\n  \"groupUIDAttribute\": \"dn\"\n  \"groupsQuery\":\n    \"baseDN\"\
+    : \"ou=Groups,dc=company,dc=tld\"\n    \"derefAliases\": \"never\"\n    \"filter\"\
+    : \"(&(objectclass=groupOfUniqueNames)(|(cn=cluster-admins)))\"\n    \"pageSize\"\
+    : 0\n    \"scope\": \"sub\"\n  \"tolerateMemberNotFoundErrors\": false\n  \"tolerateMemberOutOfScopeErrors\"\
+    : false\n  \"userNameAttributes\":\n  - \"uid\"\n  \"userUIDAttribute\": \"dn\"\
+    \n  \"usersQuery\":\n    \"baseDN\": \"dc=company,dc=tld\"\n    \"derefAliases\"\
+    : \"never\"\n    \"pageSize\": 0\n    \"scope\": \"sub\"\n\"url\": \"ldaps://ldap.company.tld:636/ou=services,dc=company,dc=tld?uid\""
+  whitelist.txt: ''
+type: Opaque
+---
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  annotations: {}
+  labels:
+    name: ldap-sync-other-ldap
+  name: ldap-sync-other-ldap
+  namespace: openshift-config
+spec:
+  concurrencyPolicy: Forbid
+  failedJobsHistoryLimit: 20
+  jobTemplate:
+    spec:
+      completions: 1
+      parallelism: 1
+      template:
+        metadata:
+          labels:
+            name: ldap-sync-other-ldap
+        spec:
+          containers:
+            - args: []
+              command:
+                - oc
+                - adm
+                - groups
+                - sync
+                - --sync-config=/etc/sync-config/config.yaml
+                - --confirm
+                - --blacklist=/etc/sync-config/blacklist.txt
+                - --whitelist=/etc/sync-config/whitelist.txt
+              env: []
+              image: image-registry.openshift-image-registry.svc:5000/openshift/cli
+              imagePullPolicy: IfNotPresent
+              name: sync
+              ports: []
+              stdin: false
+              tty: false
+              volumeMounts:
+                - mountPath: /etc/sync-config-ca/
+                  name: ldap-ca
+                - mountPath: /etc/sync-config/
+                  name: sync-config
+            - args: []
+              command:
+                - oc
+                - adm
+                - groups
+                - prune
+                - --sync-config=/etc/sync-config/config.yaml
+                - --confirm
+                - --blacklist=/etc/sync-config/blacklist.txt
+                - --whitelist=/etc/sync-config/whitelist.txt
+              env: []
+              image: image-registry.openshift-image-registry.svc:5000/openshift/cli
+              imagePullPolicy: IfNotPresent
+              name: prune
+              ports: []
+              stdin: false
+              tty: false
+              volumeMounts:
+                - mountPath: /etc/sync-config-ca/
+                  name: ldap-ca
+                - mountPath: /etc/sync-config/
+                  name: sync-config
+          imagePullSecrets: []
+          initContainers: []
+          nodeSelector:
+            node-role.kubernetes.io/master: ''
+          restartPolicy: OnFailure
+          serviceAccountName: ldap-sync
+          terminationGracePeriodSeconds: 30
+          tolerations:
+            - effect: NoSchedule
+              key: node-role.kubernetes.io/master
+              operator: Exists
+          volumes:
+            - configMap:
+                name: ldap-sync-other-ldap-ca
+              name: ldap-ca
+            - name: sync-config
+              secret:
+                secretName: ldap-sync-other-ldap
   schedule: 49 * * * *
   startingDeadlineSeconds: 30
   successfulJobsHistoryLimit: 10


### PR DESCRIPTION
Previously, when configuring LDAP authentication with a server which is secured by a certificate which is signed by a CA which is part of the OCP4 system CA bundle (e.g. Let's Encrypt), users of the component still had to supply the CA certificates in the configuration hierarchy.

With this commit, the component will ensure that the system CA bundle is used for LDAP authentication configurations for which field `ca` is not set.

This change enables users to omit CAs which are trusted through the system CA bundle from their LDAP authentication configurations.

Please note that the LDAP group sync CronJob deployed by the component is changed slightly to consume the LDAP server CA certificate from a ConfigMap rather than the Secret containing the sync configuration. This allows us to minimize the differences between configurations which use the system CA bundle and configurations which provide a custom CA certificate.

Resolves #27

## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
