### PR TITLE
Fix ConfigMap manifest for generated CA bundle

### DIFF
--- a/tests/golden/defaults/openshift4-authentication/openshift4-authentication/20_ldap_sync.yaml
+++ b/tests/golden/defaults/openshift4-authentication/openshift4-authentication/20_ldap_sync.yaml
@@ -154,7 +154,6 @@ spec:
   successfulJobsHistoryLimit: 10
 ---
 apiVersion: v1
-data: {}
 kind: ConfigMap
 metadata:
   annotations:


### PR DESCRIPTION
We need to ensure that the ConfigMap manifest which is generated when we want to inject the OpenShift CA bundle doesn't have a `data` key. Otherwise ArgoCD will continually remove the CA bundle and OpenShift will add it again.

Follow-up for #57 


## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
