### PR TITLE
Allow access to monitoring rules for sudoers group

### DIFF
--- a/component/rbac.libsonnet
+++ b/component/rbac.libsonnet
@@ -79,6 +79,25 @@ local sudoAlertmanagerAccess =
     },
   };
 
+local sudoMonitoringRulesView =
+  local sanitizedGroupName = kube.hyphenate(
+    std.strReplace(
+      std.asciiLower(params.sudoGroupName), ' ', '-'
+    )
+  );
+  kube.ClusterRoleBinding('monitoring-rules-view' + sanitizedGroupName) {
+    subjects: [ {
+      apiGroup: 'rbac.authorization.k8s.io',
+      kind: 'Group',
+      name: params.sudoGroupName,
+    } ],
+    roleRef_: {
+      kind: 'ClusterRole',
+      metadata: {
+        name: 'monitoring-rules-view',
+      },
+    },
+  };
 
 [
   sudoClusterRole,
@@ -86,4 +105,5 @@ local sudoAlertmanagerAccess =
   sudoClusterRoleBindingView,
   clusterRoleBindingAdmin,
   sudoAlertmanagerAccess,
+  sudoMonitoringRulesView,
 ]

--- a/component/rbac.libsonnet
+++ b/component/rbac.libsonnet
@@ -85,7 +85,7 @@ local sudoMonitoringRulesView =
       std.asciiLower(params.sudoGroupName), ' ', '-'
     )
   );
-  kube.ClusterRoleBinding('monitoring-rules-view' + sanitizedGroupName) {
+  kube.ClusterRoleBinding('monitoring-rules-view-' + sanitizedGroupName) {
     subjects: [ {
       apiGroup: 'rbac.authorization.k8s.io',
       kind: 'Group',

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -46,7 +46,7 @@ Using https://kubernetes.io/docs/reference/access-authn-authz/authentication/#us
 oc --as cluster-admin get secret
 ----
 
-The component also deploys a `RoleBinding` and a `ClusterRoleBinding` to ensure that users in the sudoers group can access the OpenShift cluster monitoring Alertmanager and its resource in the OpenShift console.
+The component also deploys a `RoleBinding` and a `ClusterRoleBinding` to ensure that users in the sudoers group can access the OpenShift cluster monitoring Alertmanager and its associated resources in the OpenShift console.
 
 See https://kb.vshn.ch/oc4/how-tos/authentication/sudo.html[how-to] and https://kb.vshn.ch/oc4/explanations/sudo.html[explanation] for further details.
 

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -46,7 +46,7 @@ Using https://kubernetes.io/docs/reference/access-authn-authz/authentication/#us
 oc --as cluster-admin get secret
 ----
 
-The component also deploys a `RoleBinding` to ensure that users in the sudoers group can access the OpenShift cluster monitoring Alertmanager.
+The component also deploys a `RoleBinding` and a `ClusterRoleBinding` to ensure that users in the sudoers group can access the OpenShift cluster monitoring Alertmanager and its resource in the OpenShift console.
 
 See https://kb.vshn.ch/oc4/how-tos/authentication/sudo.html[how-to] and https://kb.vshn.ch/oc4/explanations/sudo.html[explanation] for further details.
 

--- a/tests/golden/defaults/openshift4-authentication/openshift4-authentication/30_rbac.yaml
+++ b/tests/golden/defaults/openshift4-authentication/openshift4-authentication/30_rbac.yaml
@@ -88,3 +88,19 @@ subjects:
   - apiGroup: rbac.authorization.k8s.io
     kind: Group
     name: sudoers Group
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations: {}
+  labels:
+    name: monitoring-rules-view-sudoers-group
+  name: monitoring-rules-view-sudoers-group
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: monitoring-rules-view
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: sudoers Group


### PR DESCRIPTION
Add a `ClusterRoleBinding` for `monitoring-rules-view` for sudoers group

Fixes #60 

## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
