### PR TITLE
Allow multiple sudoer groups

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -1,7 +1,11 @@
 parameters:
   openshift4_authentication:
     namespace: openshift-config
-    sudoGroupName: sudoers
+    # Deprecated: add name to 'sudoGroups' instead.
+    sudoGroupName: null
+    sudoGroups:
+      - sudoers
+
     # Username to be used for impersonation, aka sudo
     adminUserName: cluster-admin
     identityProviders: {}

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -3,8 +3,7 @@ parameters:
     namespace: openshift-config
     # Deprecated: add name to 'sudoGroups' instead.
     sudoGroupName: null
-    sudoGroups:
-      - sudoers
+    sudoGroups: []
 
     # Username to be used for impersonation, aka sudo
     adminUserName: cluster-admin

--- a/component/rbac.libsonnet
+++ b/component/rbac.libsonnet
@@ -7,18 +7,18 @@ local inv = kap.inventory();
 local params = inv.parameters.openshift4_authentication;
 
 local sudoGroups =
-  if params.sudoGroupName != null && params.sudoGroupName != '' then
-    [
+  local legacyGroup =
+    if params.sudoGroupName != null && params.sudoGroupName != '' then
       std.trace(
         (
           '\nParameter `sudoGroupName` is deprecated.\n' +
           'Please update your config to use `sudoGroups` instead.'
         ),
-        params.sudoGroupName
-      ),
-    ]
-  else
-    com.renderArray(params.sudoGroups);
+        [ params.sudoGroupName ]
+      )
+    else
+      [];
+  com.renderArray(legacyGroup + params.sudoGroups);
 
 local sudoGroupSubjects = std.map(
   function(g) {

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -38,7 +38,7 @@ In this scenario, if the LDAP sync cronjob is scheduled on the master nodes, we 
 
 RBAC rules are set up in order to allow a sudo like method to gain cluster-admin privileges.
 
-By default only `cluster-read` and `impersonate` permissions are granted to the group defined in `openshift4_authentication.sudoGroupName`.
+By default only `cluster-read` and `impersonate` permissions are granted to the groups defined in `openshift4_authentication.sudoGroups`.
 Using https://kubernetes.io/docs/reference/access-authn-authz/authentication/#user-impersonation[user impersonation], permissions can be escalated to full `cluster-admin`:
 
 [source,console]

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -16,10 +16,40 @@ IMPORTANT: The component may not work correctly if this parameter is changed.
 
 [horizontal]
 type:: string
-default:: `sudoers`
+default:: `null`
 
 The OpenShift group name for which the component configures RBAC to allow members to impersonate the cluster administrator.
 See xref:index.adoc#_cluster_admin_sudo[Cluster Admin Sudo] for more details.
+
+[WARNING]
+====
+This parameter is deprecated and will be removed in a future release.
+Use `sudoGroups` instead.
+
+To keep compatibility with existing installations, this parameter overrides `sudoGroups` if set.
+====
+
+
+== `sudoGroups`
+
+[horizontal]
+type:: list
+default:: `["sudoers"]`
+
+The OpenShift group names for which the component configures RBAC to allow members to impersonate the cluster administrator.
+See xref:index.adoc#_cluster_admin_sudo[Cluster Admin Sudo] for more details.
+
+Groups can be removed from the hierarchy by prefixing them with a `~` character.
+
+=== Example
+
+[source,yaml]
+----
+sudoGroups:
+- ~sudoers
+- admins
+----
+
 
 == `adminUserName`
 

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -32,7 +32,7 @@ Use `sudoGroups` instead.
 
 [horizontal]
 type:: list
-default:: `["sudoers"]`
+default:: `[]`
 
 The OpenShift group names for which the component configures RBAC to allow members to impersonate the cluster administrator.
 See xref:index.adoc#_cluster_admin_sudo[Cluster Admin Sudo] for more details.

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -25,8 +25,6 @@ See xref:index.adoc#_cluster_admin_sudo[Cluster Admin Sudo] for more details.
 ====
 This parameter is deprecated and will be removed in a future release.
 Use `sudoGroups` instead.
-
-To keep compatibility with existing installations, this parameter overrides `sudoGroups` if set.
 ====
 
 

--- a/tests/defaults.yml
+++ b/tests/defaults.yml
@@ -10,7 +10,6 @@ parameters:
 
   openshift4_authentication:
     sudoGroups:
-      - ~sudoers
       - Customer sudoers
       - Team sudoers
     groupMemberships:

--- a/tests/defaults.yml
+++ b/tests/defaults.yml
@@ -9,7 +9,10 @@ parameters:
     namespace: syn-espejo
 
   openshift4_authentication:
-    sudoGroupName: sudoers Group
+    sudoGroups:
+      - ~sudoers
+      - Customer sudoers
+      - Team sudoers
     groupMemberships:
       test-group:
         users:

--- a/tests/golden/defaults/openshift4-authentication/openshift4-authentication/30_rbac.yaml
+++ b/tests/golden/defaults/openshift4-authentication/openshift4-authentication/30_rbac.yaml
@@ -38,7 +38,10 @@ roleRef:
 subjects:
   - apiGroup: rbac.authorization.k8s.io
     kind: Group
-    name: sudoers Group
+    name: Customer sudoers
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: Team sudoers
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -54,7 +57,10 @@ roleRef:
 subjects:
   - apiGroup: rbac.authorization.k8s.io
     kind: Group
-    name: sudoers Group
+    name: Customer sudoers
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: Team sudoers
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -77,8 +83,8 @@ kind: RoleBinding
 metadata:
   annotations: {}
   labels:
-    name: alertmanager-access-sudoers-group
-  name: alertmanager-access-sudoers-group
+    name: alertmanager-access-sudoer-groups
+  name: alertmanager-access-sudoer-groups
   namespace: openshift-monitoring
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -87,15 +93,18 @@ roleRef:
 subjects:
   - apiGroup: rbac.authorization.k8s.io
     kind: Group
-    name: sudoers Group
+    name: Customer sudoers
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: Team sudoers
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   annotations: {}
   labels:
-    name: monitoring-rules-view-sudoers-group
-  name: monitoring-rules-view-sudoers-group
+    name: monitoring-rules-view-sudoer-groups
+  name: monitoring-rules-view-sudoer-groups
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -103,4 +112,7 @@ roleRef:
 subjects:
   - apiGroup: rbac.authorization.k8s.io
     kind: Group
-    name: sudoers Group
+    name: Customer sudoers
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: Team sudoers


### PR DESCRIPTION
Fixes #62 

Adds a list `sudoGroups` and deprecates the parameter `sudoGroupName`.

## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
