### PR TITLE
Allow sudoers to impersonate users, groups, and SAs

### DIFF
--- a/component/rbac.libsonnet
+++ b/component/rbac.libsonnet
@@ -31,7 +31,7 @@ local sudoGroupSubjects = std.map(
 local sudoClusterRole = kube.ClusterRole('sudo-impersonator') {
   rules: [ {
     apiGroups: [ '' ],
-    resources: [ 'users', 'serviceaccounts' ],
+    resources: [ 'users', 'serviceaccounts', 'groups' ],
     verbs: [ 'impersonate' ],
   }, {
     apiGroups: [ 'rbac.authorization.k8s.io' ],

--- a/component/rbac.libsonnet
+++ b/component/rbac.libsonnet
@@ -31,9 +31,8 @@ local sudoGroupSubjects = std.map(
 local sudoClusterRole = kube.ClusterRole('sudo-impersonator') {
   rules: [ {
     apiGroups: [ '' ],
-    resources: [ 'users' ],
+    resources: [ 'users', 'serviceaccounts' ],
     verbs: [ 'impersonate' ],
-    resourceNames: [ params.adminUserName ],
   }, {
     apiGroups: [ 'rbac.authorization.k8s.io' ],
     resources: [ 'clusterrolebindings', 'rolebindings' ],

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -56,7 +56,8 @@ See https://kb.vshn.ch/oc4/how-tos/authentication/sudo.html[how-to] and https://
 
 This allows users in the sudoers group to impersonate other users in the cluster.
 
-You may check the permissions of a user or service account by running:
+This is especially useful for debugging RBAC issues affecting other users.
+You can check the permissions of a user or service account by running:
 
 [source,console]
 ----
@@ -64,7 +65,18 @@ kubectl --as=system:serviceaccount:NS:SERVICEACCOUNT auth can-i get deployments/
 kubectl --as=USER auth can-i get deployments/test
 ----
 
-Impersonation is logged in the Kube API server audit logs.
+When impersonating a user, their groups aren't included in the impersonation.
+It's however possible to add groups to the impersonated user:
+
+[source,console]
+----
+kubectl --as=USER --as-group=GROUP auth can-i get deployments/test <1>
+----
+<1> It's not necessary to pass an existing user if you only want to impersonate groups.
+
+Group impersonation is only possible when impersonating a user.
+
+Impersonation is logged in the Kubernetes API server audit logs.
 
 [source,console]
 ----

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -50,6 +50,42 @@ The component also deploys a `RoleBinding` and a `ClusterRoleBinding` to ensure 
 
 See https://kb.vshn.ch/oc4/how-tos/authentication/sudo.html[how-to] and https://kb.vshn.ch/oc4/explanations/sudo.html[explanation] for further details.
 
+== Impersonating Users
+
+`impersonate` permissions are granted to the groups defined in `openshift4_authentication.sudoGroups`.
+
+This allows users in the sudoers group to impersonate other users in the cluster.
+
+You may check the permissions of a user or service account by running:
+
+[source,console]
+----
+kubectl --as=system:serviceaccount:NS:SERVICEACCOUNT auth can-i get deployments/test
+kubectl --as=USER auth can-i get deployments/test
+----
+
+Impersonation is logged in the Kube API server audit logs.
+
+[source,console]
+----
+❯ oc adm node-logs --role=master --path=kube-apiserver/audit.log | grep "impersonatedUser" | jq
+{
+  "kind": "Event",
+  [...]
+  "verb": "get",
+  "user":
+    {
+      "username": "chuck.testa",
+    },
+  "impersonatedUser":
+    {
+      "username": "john.dwight",
+      "groups": ["system:authenticated"]
+    },
+[...]
+}
+----
+
 == Removing the kubeadmin user
 
 The component deploys an Espejo syncconfig which deletes the `kubeadmin` secret in namespace `kube-system`.

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -18,8 +18,8 @@ IMPORTANT: The component may not work correctly if this parameter is changed.
 type:: string
 default:: `null`
 
-The OpenShift group name for which the component configures RBAC to allow members to impersonate the cluster administrator.
-See xref:index.adoc#_cluster_admin_sudo[Cluster Admin Sudo] for more details.
+The OpenShift group name for which the component configures RBAC to allow members to impersonate users and service accounts, including the cluster administrator.
+See xref:index.adoc#_cluster_admin_sudo[Cluster Admin Sudo] and xref:index.adoc#_impersonating_users[Impersonating Users] for more details.
 
 [WARNING]
 ====
@@ -34,10 +34,11 @@ Use `sudoGroups` instead.
 type:: list
 default:: `[]`
 
-The OpenShift group names for which the component configures RBAC to allow members to impersonate the cluster administrator.
-See xref:index.adoc#_cluster_admin_sudo[Cluster Admin Sudo] for more details.
+The OpenShift group names for which the component configures RBAC to allow members to impersonate users and service accounts, including the cluster administrator.
+See xref:index.adoc#_cluster_admin_sudo[Cluster Admin Sudo] and xref:index.adoc#_impersonating_users[Impersonating Users] for more details.
 
 Groups can be removed from the hierarchy by prefixing them with a `~` character.
+
 
 === Example
 

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -18,7 +18,7 @@ IMPORTANT: The component may not work correctly if this parameter is changed.
 type:: string
 default:: `null`
 
-The OpenShift group name for which the component configures RBAC to allow members to impersonate users and service accounts, including the cluster administrator.
+The OpenShift group name for which the component configures RBAC to allow members to impersonate users, groups, and service accounts, including the cluster administrator.
 See xref:index.adoc#_cluster_admin_sudo[Cluster Admin Sudo] and xref:index.adoc#_impersonating_users[Impersonating Users] for more details.
 
 [WARNING]
@@ -34,7 +34,7 @@ Use `sudoGroups` instead.
 type:: list
 default:: `[]`
 
-The OpenShift group names for which the component configures RBAC to allow members to impersonate users and service accounts, including the cluster administrator.
+The OpenShift group names for which the component configures RBAC to allow members to impersonate users, groups, and service accounts, including the cluster administrator.
 See xref:index.adoc#_cluster_admin_sudo[Cluster Admin Sudo] and xref:index.adoc#_impersonating_users[Impersonating Users] for more details.
 
 Groups can be removed from the hierarchy by prefixing them with a `~` character.

--- a/tests/golden/defaults/openshift4-authentication/openshift4-authentication/30_rbac.yaml
+++ b/tests/golden/defaults/openshift4-authentication/openshift4-authentication/30_rbac.yaml
@@ -11,6 +11,7 @@ rules:
     resources:
       - users
       - serviceaccounts
+      - groups
     verbs:
       - impersonate
   - apiGroups:

--- a/tests/golden/defaults/openshift4-authentication/openshift4-authentication/30_rbac.yaml
+++ b/tests/golden/defaults/openshift4-authentication/openshift4-authentication/30_rbac.yaml
@@ -8,10 +8,9 @@ metadata:
 rules:
   - apiGroups:
       - ''
-    resourceNames:
-      - cluster-admin
     resources:
       - users
+      - serviceaccounts
     verbs:
       - impersonate
   - apiGroups:

--- a/tests/golden/no-ldap/openshift4-authentication/openshift4-authentication/30_rbac.yaml
+++ b/tests/golden/no-ldap/openshift4-authentication/openshift4-authentication/30_rbac.yaml
@@ -11,6 +11,7 @@ rules:
     resources:
       - users
       - serviceaccounts
+      - groups
     verbs:
       - impersonate
   - apiGroups:

--- a/tests/golden/no-ldap/openshift4-authentication/openshift4-authentication/30_rbac.yaml
+++ b/tests/golden/no-ldap/openshift4-authentication/openshift4-authentication/30_rbac.yaml
@@ -8,10 +8,9 @@ metadata:
 rules:
   - apiGroups:
       - ''
-    resourceNames:
-      - cluster-admin
     resources:
       - users
+      - serviceaccounts
     verbs:
       - impersonate
   - apiGroups:


### PR DESCRIPTION
This allows sudoers to check permissions using `kubectl --as=system:serviceaccount:ns:sa auth can-i get pods`.

AFAIK it is not possible to limit impersonation to `SelfSubjectAccessReview`, but impersonations are logged in the audit logs.

```
❯ oc adm node-logs --role=master --path=kube-apiserver/audit.log | grep "impersonatedUser" | jq
{
  "kind": "Event",
  [...]
  "verb": "get",
  "user":
    {
      "username": "sebastian.widmer",
    },
  "impersonatedUser":
    { 
      "username": "cluster-admin", 
      "groups": ["system:authenticated"] 
    },
[...]
}
```

## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
