### PR TITLE
Fix console impersonation

### DIFF
--- a/component/rbac.libsonnet
+++ b/component/rbac.libsonnet
@@ -30,7 +30,7 @@ local sudoGroupSubjects = std.map(
 
 local sudoClusterRole = kube.ClusterRole('sudo-impersonator') {
   rules: [ {
-    apiGroups: [ '' ],
+    apiGroups: [ '', 'authorization.k8s.io' ],
     resources: [ 'users', 'serviceaccounts', 'groups' ],
     verbs: [ 'impersonate' ],
   }, {

--- a/tests/golden/defaults/openshift4-authentication/openshift4-authentication/30_rbac.yaml
+++ b/tests/golden/defaults/openshift4-authentication/openshift4-authentication/30_rbac.yaml
@@ -8,6 +8,7 @@ metadata:
 rules:
   - apiGroups:
       - ''
+      - authorization.k8s.io
     resources:
       - users
       - serviceaccounts

--- a/tests/golden/no-ldap/openshift4-authentication/openshift4-authentication/30_rbac.yaml
+++ b/tests/golden/no-ldap/openshift4-authentication/openshift4-authentication/30_rbac.yaml
@@ -8,6 +8,7 @@ metadata:
 rules:
   - apiGroups:
       - ''
+      - authorization.k8s.io
     resources:
       - users
       - serviceaccounts


### PR DESCRIPTION
The console started checking with the following `SelfSubjectAccessReview`:

```
{
  "kind": "SelfSubjectAccessReview",
  "apiVersion": "authorization.k8s.io/v1",
  "metadata": {
    "creationTimestamp": null,
  },
  "spec": {
    "resourceAttributes": {
      "verb": "impersonate",
      "group": "authorization.k8s.io",
      "resource": "users",
      "name": "cluster-admin"
    }
  },
  "status": {
    "allowed": false
  }
}
```

Both `users.authorization.k8s.io` and `users` seem to be correct to receive impersonation rights in the API server.




## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
