### PR TITLE
Fix ArgoCD sync for the oauth-templates secret

### DIFF
--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -20,6 +20,10 @@ local hasTokenMaxAge = std.type(params.token.maxAgeSeconds) == 'number';
 local hasTokenConfig = hasTokenTimeouts || hasTokenMaxAge;
 
 local template = com.namespaced(params.namespace, kube.Secret('oauth-templates') {
+  metadata+: {
+    annotations+: common.argoAnnotations,
+    labels+: common.commonLabels,
+  },
   data:: {},
   stringData: {
     [if hasErrorTemplate then 'errors.html']: params.templates.err,


### PR DESCRIPTION
This secret is copied from `openshift-config` to
`openshift-authentication` by OpenShift.  Because the secret is copied with all labels, we need to add annotations to ensure that ArgoCD doesn't prune the copy.


## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
