### PR TITLE
Support managing self-provisioners

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -7,6 +7,9 @@ parameters:
     sudoGroupName: null
     sudoGroups: []
 
+    selfProvisionerGroups:
+      - system:authenticated:oauth
+
     identityProviders: {}
 
     templates:

--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -6,6 +6,7 @@ local esp = import 'lib/espejote.libsonnet';
 local kap = import 'lib/kapitan.libjsonnet';
 local kube = import 'kube-ssa-compat.libsonnet';
 local rbac = import 'rbac.libsonnet';
+local sp = import 'self-provisioning.libsonnet';
 local inv = kap.inventory();
 // The hiera parameters for the component
 local params = inv.parameters.openshift4_authentication;
@@ -186,4 +187,5 @@ local removeKubeAdmin =
   [if std.length(ldapSync) > 0 then '20_ldap_sync']: ldapSync,
   '30_rbac': rbac,
   '40_remove_kubeadmin_managedresource': removeKubeAdmin,
+  '50_self_provisioning': sp.selfProvisioning,
 }

--- a/component/self-provisioning.libsonnet
+++ b/component/self-provisioning.libsonnet
@@ -1,0 +1,120 @@
+local common = import 'common.libsonnet';
+local com = import 'lib/commodore.libjsonnet';
+local esp = import 'lib/espejote.libsonnet';
+local kap = import 'lib/kapitan.libjsonnet';
+
+// The hiera parameters for the component
+local inv = kap.inventory();
+local params = inv.parameters.openshift4_authentication;
+
+local metadataPatch = {
+  annotations+: {
+    'syn.tools/source': 'https://github.com/appuio/component-openshift4-authentication.git',
+  },
+  labels+: {
+    'app.kubernetes.io/managed-by': 'espejote',
+    'app.kubernetes.io/part-of': 'syn',
+    'app.kubernetes.io/component': 'openshift4-authentication',
+  },
+};
+
+local patch = {
+  apiVersion: 'rbac.authorization.k8s.io/v1',
+  kind: 'ClusterRoleBinding',
+  metadata: {
+    name: 'self-provisioners',
+  },
+  roleRef: {
+    apiGroup: 'rbac.authorization.k8s.io',
+    kind: 'ClusterRole',
+    name: 'self-provisioner',
+  },
+  subjects: [
+    {
+      apiGroup: 'rbac.authorization.k8s.io',
+      kind: 'Group',
+      name: group,
+    }
+    for group in com.renderArray(params.selfProvisionerGroups)
+  ],
+};
+
+local serviceAccount = {
+  apiVersion: 'v1',
+  kind: 'ServiceAccount',
+  metadata: {
+    name: 'rbac-clusterrolebinding-self-provisioners',
+    namespace: inv.parameters.espejote.namespace,
+  } + metadataPatch,
+};
+
+local clusterRole = {
+  apiVersion: 'rbac.authorization.k8s.io/v1',
+  kind: 'ClusterRole',
+  metadata: {
+    name: 'syn-espejote:rbac-clusterrolebinding-self-provisioners',
+  } + metadataPatch,
+  rules: [
+    {
+      apiGroups: [ '', 'project.openshift.io' ],
+      resources: [ 'projectrequests' ],
+      verbs: [ 'create' ],
+    },
+    {
+      apiGroups: [ 'rbac.authorization.k8s.io' ],
+      resources: [ 'clusterrolebindings' ],
+      resourceNames: [ 'self-provisioners' ],
+      verbs: [ '*' ],
+    },
+  ],
+};
+
+local clusterRoleBinding = {
+  apiVersion: 'rbac.authorization.k8s.io/v1',
+  kind: 'ClusterRoleBinding',
+  metadata: {
+    name: 'syn-espejote:rbac-clusterrolebinding-self-provisioners',
+  } + metadataPatch,
+  roleRef: {
+    apiGroup: 'rbac.authorization.k8s.io',
+    kind: 'ClusterRole',
+    name: clusterRole.metadata.name,
+  },
+  subjects: [
+    {
+      kind: 'ServiceAccount',
+      name: serviceAccount.metadata.name,
+      namespace: serviceAccount.metadata.namespace,
+    },
+  ],
+};
+
+local managedResource = esp.managedResource('rbac-clusterrolebinding-self-provisioners', inv.parameters.espejote.namespace) {
+  metadata+: metadataPatch,
+  spec: {
+    applyOptions: {
+      force: true,
+    },
+    serviceAccountRef: {
+      name: serviceAccount.metadata.name,
+    },
+    template: std.manifestJson(patch),
+    triggers: [ {
+      name: 'clusterrolebinding',
+      watchResource: {
+        apiVersion: patch.apiVersion,
+        kind: patch.kind,
+        name: patch.metadata.name,
+      },
+    } ],
+  },
+};
+
+{
+  selfProvisioning: [
+    serviceAccount,
+    clusterRole,
+    clusterRoleBinding,
+    managedResource,
+  ],
+}

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -40,6 +40,24 @@ See xref:index.adoc#_cluster_admin_sudo[Cluster Admin Sudo] and xref:index.adoc#
 Groups can be removed from the hierarchy by prefixing them with a `~` character.
 
 
+== `selfProvisionerGroups`
+
+[horizontal]
+type:: list
+default::
++
+[source,yaml]
+----
+selfProvisionerGroups:
+  - system:authenticated:oauth
+----
+
+The OpenShift group names for which the component allows self provisioning of projects/namespaces.
+See https://docs.redhat.com/en/documentation/openshift_container_platform/4.20/html/postinstallation_configuration/post-install-preparing-for-users#default-roles_post-install-preparing-for-users[Default ClusterRoles] for more details.
+
+Groups can be removed from the hierarchy by prefixing them with a `~` character.
+
+
 === Example
 
 [source,yaml]

--- a/tests/defaults.yml
+++ b/tests/defaults.yml
@@ -1,9 +1,14 @@
+applications:
+  - espejote
+
 parameters:
   kapitan:
     dependencies:
       - type: https
-        source: https://raw.githubusercontent.com/projectsyn/component-espejote/v0.14.0/lib/espejote.libsonnet
+        source: https://raw.githubusercontent.com/projectsyn/component-espejote/master/lib/espejote.libsonnet
         output_path: vendor/lib/espejote.libsonnet
+  espejote:
+    namespace: syn-espejote
 
   openshift4_authentication:
     sudoGroups:

--- a/tests/golden/defaults/openshift4-authentication/openshift4-authentication/50_self_provisioning.yaml
+++ b/tests/golden/defaults/openshift4-authentication/openshift4-authentication/50_self_provisioning.yaml
@@ -1,0 +1,101 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:
+    syn.tools/source: https://github.com/appuio/component-openshift4-authentication.git
+  labels:
+    app.kubernetes.io/component: openshift4-authentication
+    app.kubernetes.io/managed-by: espejote
+    app.kubernetes.io/part-of: syn
+  name: rbac-clusterrolebinding-self-provisioners
+  namespace: syn-espejote
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    syn.tools/source: https://github.com/appuio/component-openshift4-authentication.git
+  labels:
+    app.kubernetes.io/component: openshift4-authentication
+    app.kubernetes.io/managed-by: espejote
+    app.kubernetes.io/part-of: syn
+  name: syn-espejote:rbac-clusterrolebinding-self-provisioners
+rules:
+  - apiGroups:
+      - ''
+      - project.openshift.io
+    resources:
+      - projectrequests
+    verbs:
+      - create
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resourceNames:
+      - self-provisioners
+    resources:
+      - clusterrolebindings
+    verbs:
+      - '*'
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations:
+    syn.tools/source: https://github.com/appuio/component-openshift4-authentication.git
+  labels:
+    app.kubernetes.io/component: openshift4-authentication
+    app.kubernetes.io/managed-by: espejote
+    app.kubernetes.io/part-of: syn
+  name: syn-espejote:rbac-clusterrolebinding-self-provisioners
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: syn-espejote:rbac-clusterrolebinding-self-provisioners
+subjects:
+  - kind: ServiceAccount
+    name: rbac-clusterrolebinding-self-provisioners
+    namespace: syn-espejote
+---
+apiVersion: espejote.io/v1alpha1
+kind: ManagedResource
+metadata:
+  annotations:
+    syn.tools/source: https://github.com/appuio/component-openshift4-authentication.git
+  labels:
+    app.kubernetes.io/component: openshift4-authentication
+    app.kubernetes.io/managed-by: espejote
+    app.kubernetes.io/name: rbac-clusterrolebinding-self-provisioners
+    app.kubernetes.io/part-of: syn
+  name: rbac-clusterrolebinding-self-provisioners
+  namespace: syn-espejote
+spec:
+  applyOptions:
+    force: true
+  serviceAccountRef:
+    name: rbac-clusterrolebinding-self-provisioners
+  template: |-
+    {
+        "apiVersion": "rbac.authorization.k8s.io/v1",
+        "kind": "ClusterRoleBinding",
+        "metadata": {
+            "name": "self-provisioners"
+        },
+        "roleRef": {
+            "apiGroup": "rbac.authorization.k8s.io",
+            "kind": "ClusterRole",
+            "name": "self-provisioner"
+        },
+        "subjects": [
+            {
+                "apiGroup": "rbac.authorization.k8s.io",
+                "kind": "Group",
+                "name": "system:authenticated:oauth"
+            }
+        ]
+    }
+  triggers:
+    - name: clusterrolebinding
+      watchResource:
+        apiVersion: rbac.authorization.k8s.io/v1
+        kind: ClusterRoleBinding
+        name: self-provisioners

--- a/tests/golden/no-ldap/openshift4-authentication/openshift4-authentication/50_self_provisioning.yaml
+++ b/tests/golden/no-ldap/openshift4-authentication/openshift4-authentication/50_self_provisioning.yaml
@@ -1,0 +1,97 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:
+    syn.tools/source: https://github.com/appuio/component-openshift4-authentication.git
+  labels:
+    app.kubernetes.io/component: openshift4-authentication
+    app.kubernetes.io/managed-by: espejote
+    app.kubernetes.io/part-of: syn
+  name: rbac-clusterrolebinding-self-provisioners
+  namespace: syn-espejote
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    syn.tools/source: https://github.com/appuio/component-openshift4-authentication.git
+  labels:
+    app.kubernetes.io/component: openshift4-authentication
+    app.kubernetes.io/managed-by: espejote
+    app.kubernetes.io/part-of: syn
+  name: syn-espejote:rbac-clusterrolebinding-self-provisioners
+rules:
+  - apiGroups:
+      - ''
+      - project.openshift.io
+    resources:
+      - projectrequests
+    verbs:
+      - create
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resourceNames:
+      - self-provisioners
+    resources:
+      - clusterrolebindings
+    verbs:
+      - '*'
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations:
+    syn.tools/source: https://github.com/appuio/component-openshift4-authentication.git
+  labels:
+    app.kubernetes.io/component: openshift4-authentication
+    app.kubernetes.io/managed-by: espejote
+    app.kubernetes.io/part-of: syn
+  name: syn-espejote:rbac-clusterrolebinding-self-provisioners
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: syn-espejote:rbac-clusterrolebinding-self-provisioners
+subjects:
+  - kind: ServiceAccount
+    name: rbac-clusterrolebinding-self-provisioners
+    namespace: syn-espejote
+---
+apiVersion: espejote.io/v1alpha1
+kind: ManagedResource
+metadata:
+  annotations:
+    syn.tools/source: https://github.com/appuio/component-openshift4-authentication.git
+  labels:
+    app.kubernetes.io/component: openshift4-authentication
+    app.kubernetes.io/managed-by: espejote
+    app.kubernetes.io/name: rbac-clusterrolebinding-self-provisioners
+    app.kubernetes.io/part-of: syn
+  name: rbac-clusterrolebinding-self-provisioners
+  namespace: syn-espejote
+spec:
+  applyOptions:
+    force: true
+  serviceAccountRef:
+    name: rbac-clusterrolebinding-self-provisioners
+  template: |-
+    {
+        "apiVersion": "rbac.authorization.k8s.io/v1",
+        "kind": "ClusterRoleBinding",
+        "metadata": {
+            "name": "self-provisioners"
+        },
+        "roleRef": {
+            "apiGroup": "rbac.authorization.k8s.io",
+            "kind": "ClusterRole",
+            "name": "self-provisioner"
+        },
+        "subjects": [
+
+        ]
+    }
+  triggers:
+    - name: clusterrolebinding
+      watchResource:
+        apiVersion: rbac.authorization.k8s.io/v1
+        kind: ClusterRoleBinding
+        name: self-provisioners

--- a/tests/no-ldap.yml
+++ b/tests/no-ldap.yml
@@ -2,5 +2,12 @@ parameters:
   kapitan:
     dependencies:
       - type: https
-        source: https://raw.githubusercontent.com/projectsyn/component-espejote/v0.14.0/lib/espejote.libsonnet
+        source: https://raw.githubusercontent.com/projectsyn/component-espejote/master/lib/espejote.libsonnet
         output_path: vendor/lib/espejote.libsonnet
+
+  espejote:
+    namespace: syn-espejote
+
+  openshift4_authentication:
+    selfProvisionerGroups:
+      - ~system:authenticated:oauth


### PR DESCRIPTION
This change allows this component to manage the self-provisioner groups.  
Attention, will reenable self-provisioning on clusters that used the patch-operator patch to disable self-provisioning.

## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [ ] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
