### PR TITLE
Annotate `self-provisioners` CRB with `autoupdate=false`

### DIFF
--- a/component/self-provisioning.libsonnet
+++ b/component/self-provisioning.libsonnet
@@ -23,6 +23,11 @@ local patch = {
   kind: 'ClusterRoleBinding',
   metadata: {
     name: 'self-provisioners',
+    annotations: {
+      // NOTE(sg): Set autoupdate=false to ensure that K8s/OpenShift don't
+      // update the subjects of this clusterrolebinding.
+      'rbac.authorization.kubernetes.io/autoupdate': 'false',
+    },
   },
   roleRef: {
     apiGroup: 'rbac.authorization.k8s.io',

--- a/tests/golden/defaults/openshift4-authentication/openshift4-authentication/50_self_provisioning.yaml
+++ b/tests/golden/defaults/openshift4-authentication/openshift4-authentication/50_self_provisioning.yaml
@@ -78,6 +78,9 @@ spec:
         "apiVersion": "rbac.authorization.k8s.io/v1",
         "kind": "ClusterRoleBinding",
         "metadata": {
+            "annotations": {
+                "rbac.authorization.kubernetes.io/autoupdate": "false"
+            },
             "name": "self-provisioners"
         },
         "roleRef": {

--- a/tests/golden/no-ldap/openshift4-authentication/openshift4-authentication/50_self_provisioning.yaml
+++ b/tests/golden/no-ldap/openshift4-authentication/openshift4-authentication/50_self_provisioning.yaml
@@ -78,6 +78,9 @@ spec:
         "apiVersion": "rbac.authorization.k8s.io/v1",
         "kind": "ClusterRoleBinding",
         "metadata": {
+            "annotations": {
+                "rbac.authorization.kubernetes.io/autoupdate": "false"
+            },
             "name": "self-provisioners"
         },
         "roleRef": {


### PR DESCRIPTION
The OpenShift documentation (cf. step 4 of https://docs.redhat.com/en/documentation/openshift_container_platform/4.20/html/building_applications/projects#disabling-project-self-provisioning_configuring-project-creation) states that the `self-provisioners` clusterrolebinding must be annotated with `rbac.authorization.k8s.io/autoupdate=false` to ensure that user-supplied changes aren't reverted.

This commit updates our Espejote-based patch to apply that annotation.

Fixes #108 


## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
